### PR TITLE
Add financial graphs with graph-element

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,28 @@
     data='{"nodes":[{"id":"A","x":50,"y":50},{"id":"B","x":200,"y":50},{"id":"C","x":125,"y":200}],"edges":[{"from":"A","to":"B"},{"from":"A","to":"C"},{"from":"B","to":"C"}]}'
     trace='[["A","B","C"],["A","C"]]'></graph-element>
 
+  <h2>Financial Data</h2>
+
+  <!-- Income graph -->
+  <graph-element
+    data='{"nodes":[{"id":"Jan 2025","x":50,"y":110.0},{"id":"Feb 2025","x":90,"y":123.33},{"id":"Mar 2025","x":130,"y":80.0},{"id":"Apr 2025","x":170,"y":86.67},{"id":"May 2025","x":210,"y":50.0},{"id":"Jun 2025","x":250,"y":136.67}],"edges":[{"from":"Jan 2025","to":"Feb 2025"},{"from":"Feb 2025","to":"Mar 2025"},{"from":"Mar 2025","to":"Apr 2025"},{"from":"Apr 2025","to":"May 2025"},{"from":"May 2025","to":"Jun 2025"}]}'
+    trace='["Jan 2025","Feb 2025","Mar 2025","Apr 2025","May 2025","Jun 2025"]'></graph-element>
+
+  <!-- Expenses graph -->
+  <graph-element
+    data='{"nodes":[{"id":"Jan 2025","x":50,"y":106.67},{"id":"Feb 2025","x":90,"y":143.33},{"id":"Mar 2025","x":130,"y":63.33},{"id":"Apr 2025","x":170,"y":50.0},{"id":"May 2025","x":210,"y":83.33},{"id":"Jun 2025","x":250,"y":183.33}],"edges":[{"from":"Jan 2025","to":"Feb 2025"},{"from":"Feb 2025","to":"Mar 2025"},{"from":"Mar 2025","to":"Apr 2025"},{"from":"Apr 2025","to":"May 2025"},{"from":"May 2025","to":"Jun 2025"}]}'
+    trace='["Jan 2025","Feb 2025","Mar 2025","Apr 2025","May 2025","Jun 2025"]'></graph-element>
+
+  <!-- Net Profit graph -->
+  <graph-element
+    data='{"nodes":[{"id":"Jan 2025","x":50,"y":132.86},{"id":"Feb 2025","x":90,"y":124.29},{"id":"Mar 2025","x":130,"y":118.57},{"id":"Apr 2025","x":170,"y":141.43},{"id":"May 2025","x":210,"y":50.0},{"id":"Jun 2025","x":250,"y":112.86}],"edges":[{"from":"Jan 2025","to":"Feb 2025"},{"from":"Feb 2025","to":"Mar 2025"},{"from":"Mar 2025","to":"Apr 2025"},{"from":"Apr 2025","to":"May 2025"},{"from":"May 2025","to":"Jun 2025"}]}'
+    trace='["Jan 2025","Feb 2025","Mar 2025","Apr 2025","May 2025","Jun 2025"]'></graph-element>
+
+  <!-- Running Balance graph -->
+  <graph-element
+    data='{"nodes":[{"id":"Jan 2025","x":50,"y":221.43},{"id":"Feb 2025","x":90,"y":190.77},{"id":"Mar 2025","x":130,"y":158.71},{"id":"Apr 2025","x":170,"y":132.23},{"id":"May 2025","x":210,"y":83.45},{"id":"Jun 2025","x":250,"y":50.0}],"edges":[{"from":"Jan 2025","to":"Feb 2025"},{"from":"Feb 2025","to":"Mar 2025"},{"from":"Mar 2025","to":"Apr 2025"},{"from":"Apr 2025","to":"May 2025"},{"from":"May 2025","to":"Jun 2025"}]}'
+    trace='["Jan 2025","Feb 2025","Mar 2025","Apr 2025","May 2025","Jun 2025"]'></graph-element>
+
   <script src="graph-element.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `graph-element` charts that visualize income, expenses, net profit and running balance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68467cbcb4448322a0e0cbf4001e3ccc