### PR TITLE
Add grid overlay and zoom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,9 @@ single JSON array of node IDs or an array of such arrays to represent
 multiple traces through the graph. Edges that belong to any trace are
 drawn in blue with arrowheads to indicate direction.
 
+## Grid and Zoom
+
+The canvas now displays a light grid and you can use the mouse wheel to
+zoom in and out of the graph.
+
 Open `index.html` in a browser to see the element in action.

--- a/graph-element.js
+++ b/graph-element.js
@@ -7,6 +7,9 @@ class GraphElement extends HTMLElement {
     this.canvas.width = 300;
     this.canvas.height = 300;
     this.ctx = this.canvas.getContext('2d');
+
+    this.scale = 1;
+    this.canvas.addEventListener('wheel', e => this.onWheel(e));
   }
 
   static get observedAttributes() {
@@ -56,14 +59,25 @@ class GraphElement extends HTMLElement {
     }
   }
 
+  onWheel(e) {
+    e.preventDefault();
+    const factor = e.deltaY < 0 ? 1.1 : 0.9;
+    this.scale *= factor;
+    this.draw();
+  }
+
   draw() {
     const data = this.parseData();
     const traces = this.parseTraces();
     const ctx = this.ctx;
     ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    ctx.save();
+    ctx.scale(this.scale, this.scale);
+    this.drawGrid();
     if (!data) {
       ctx.fillStyle = '#000';
       ctx.fillText('No data', 10, 20);
+      ctx.restore();
       return;
     }
 
@@ -100,6 +114,7 @@ class GraphElement extends HTMLElement {
       ctx.fillStyle = '#000';
       ctx.fillText(node.id, node.x + 7, node.y + 3);
     });
+    ctx.restore();
   }
 
   drawArrow(from, to) {
@@ -115,6 +130,22 @@ class GraphElement extends HTMLElement {
     ctx.lineTo(tox, toy);
     ctx.fillStyle = '#00f';
     ctx.fill();
+  }
+
+  drawGrid() {
+    const ctx = this.ctx;
+    const spacing = 25;
+    ctx.strokeStyle = '#eee';
+    ctx.beginPath();
+    for (let x = 0; x <= this.canvas.width; x += spacing) {
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, this.canvas.height);
+    }
+    for (let y = 0; y <= this.canvas.height; y += spacing) {
+      ctx.moveTo(0, y);
+      ctx.lineTo(this.canvas.width, y);
+    }
+    ctx.stroke();
   }
 
   render() {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <h1>Graph Element Demo</h1>
+  <p>Use the mouse wheel to zoom the graphs.</p>
 
   <!-- Use the custom element -->
   <graph-element


### PR DESCRIPTION
## Summary
- draw a light grid behind the graph
- implement zooming via the mouse wheel
- explain the new capabilities in the README
- add a note in the demo page

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68467fd4009c8322b410445eb178ce49