### PR TITLE
Add height attribute to graph element

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,13 @@ allows you to pan around larger graphs after zooming in.
 The canvas automatically resizes to match the element's dimensions so it
 fits wherever you place it.
 
+## Custom height
+
+You can set a fixed height for the component by providing a `height`
+attribute. Numeric values are treated as pixel heights:
+
+```html
+<graph-element height="300" data="..."></graph-element>
+```
+
 Open `index.html` in a browser to see the element in action.

--- a/graph-element.js
+++ b/graph-element.js
@@ -31,12 +31,13 @@ class GraphElement extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ['data', 'trace'];
+    return ['data', 'trace', 'height'];
   }
 
   connectedCallback() {
     this.render();
     this.resizeObserver.observe(this);
+    this.updateHeight();
   }
 
   disconnectedCallback() {
@@ -46,6 +47,9 @@ class GraphElement extends HTMLElement {
   attributeChangedCallback(name, oldValue, newValue) {
     if ((name === 'data' || name === 'trace') && oldValue !== newValue) {
       this.draw();
+    }
+    if (name === 'height' && oldValue !== newValue) {
+      this.updateHeight();
     }
   }
 
@@ -80,6 +84,20 @@ class GraphElement extends HTMLElement {
       console.error('graph-element: invalid trace attribute', e);
       return [];
     }
+  }
+
+  updateHeight() {
+    const heightAttr = this.getAttribute('height');
+    if (heightAttr) {
+      if (/^\d+$/.test(heightAttr)) {
+        this.style.height = `${heightAttr}px`;
+      } else {
+        this.style.height = heightAttr;
+      }
+    } else {
+      this.style.removeProperty('height');
+    }
+    this.draw();
   }
 
   onWheel(e) {

--- a/index.html
+++ b/index.html
@@ -11,13 +11,14 @@
 
   <!-- Use the custom element -->
   <graph-element
+    height="300"
     data='{"nodes":[{"id":"A","x":50,"y":50},{"id":"B","x":200,"y":50},{"id":"C","x":125,"y":200}],"edges":[{"from":"A","to":"B"},{"from":"A","to":"C"},{"from":"B","to":"C"}]}'
     trace='[["A","B","C"],["A","C"]]'></graph-element>
 
   <h2>Financial Data</h2>
 
   <!-- Combined Financial Data graph -->
-  <graph-element id="finance-graph"></graph-element>
+  <graph-element id="finance-graph" height="300"></graph-element>
 
   <script src="graph-element.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- allow setting a `height` attribute on `<graph-element>`
- document custom height usage
- demonstrate the new attribute in `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9ef53e4832296e03bf15ba212ec